### PR TITLE
feat: validate that setOrder fee is enough to make all transactions and messageToL2

### DIFF
--- a/mm-bot/resources/schema.sql
+++ b/mm-bot/resources/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS orders
     starknet_tx_hash     VARCHAR(66)    NOT NULL, -- 66 chars
     recipient_address    VARCHAR(42)    NOT NULL, -- 0x + 40 bytes
     amount               NUMERIC(78, 0) NOT NULL, -- uint 256
+    fee                  NUMERIC(78, 0) NOT NULL, -- uint 256
     status               VARCHAR(32)    NOT NULL DEFAULT 'PENDING',
     failed               BOOLEAN        NOT NULL DEFAULT FALSE,
     tx_hash              BYTEA          NULL,     -- 32 bytes

--- a/mm-bot/src/models/order.py
+++ b/mm-bot/src/models/order.py
@@ -14,6 +14,7 @@ class Order(Base):
     starknet_tx_hash: str = Column(String(66), nullable=False)
     recipient_address: str = Column(String(42), nullable=False)
     amount: decimal = Column(Numeric(78, 0), nullable=False)
+    fee: decimal = Column(Numeric(78, 0), nullable=False)
     status: OrderStatus = Column(Enum(OrderStatus), nullable=False, default=OrderStatus.PENDING)
     failed: bool = Column(Integer, nullable=False, default=False)
     tx_hash: HexBytes = Column(LargeBinary, nullable=True)
@@ -33,3 +34,6 @@ class Order(Base):
 
     def get_int_amount(self) -> int:
         return int(self.amount)
+
+    def get_int_fee(self) -> int:
+        return int(self.fee)

--- a/mm-bot/src/services/ethereum.py
+++ b/mm-bot/src/services/ethereum.py
@@ -70,6 +70,7 @@ def transfer(deposit_id, dst_addr, amount):
 
 
 # we need amount so the transaction is valid with the transfer that will be transferred
+    # TODO separate create_transfer_unsent_tx and sign_transaction
 @use_fallback(rpc_nodes, logger, "Failed to create ethereum transfer")
 def create_transfer(deposit_id, dst_addr_bytes, amount, rpc_node=main_rpc_node):
     unsent_tx = rpc_node.contract.functions.transfer(deposit_id, dst_addr_bytes, amount).build_transaction({
@@ -119,6 +120,11 @@ def estimate_transaction_fee(transaction, rpc_node=main_rpc_node):
     fee = rpc_node.w3.eth.gas_price
     gas_fee = fee * gas_limit
     return gas_fee
+
+
+@use_fallback(rpc_nodes, logger, "Failed to get gas price")
+def get_gas_price(rpc_node=main_rpc_node):
+    return rpc_node.w3.eth.gas_price
 
 
 def is_transaction_viable(amount: int, percentage: float, gas_fee: int) -> bool:

--- a/mm-bot/src/services/overall_fee_calculator.py
+++ b/mm-bot/src/services/overall_fee_calculator.py
@@ -10,7 +10,7 @@ from services.withdrawer.ethereum_withdrawer import EthereumWithdrawer
 async def estimate_overall_fee(order: Order) -> int:
     transfer_fee = await asyncio.to_thread(estimate_transfer_fee, order)
     message_fee = await estimate_message_fee(order)
-    withdraw_fee = estimate_withdraw_fee()
+    withdraw_fee = estimate_yab_withdraw_fee()
     return transfer_fee + message_fee + withdraw_fee
 
 
@@ -24,7 +24,7 @@ def estimate_transfer_fee(order: Order) -> int:
     return estimate_transaction_fee(unsent_tx)
 
 
-def estimate_withdraw_fee() -> int:
+def estimate_yab_withdraw_fee() -> int:
     """
     Due to the deposit does not exist on ethereum at this point,
     we cannot estimate the gas fee of the withdrawal transaction

--- a/mm-bot/src/services/overall_fee_calculator.py
+++ b/mm-bot/src/services/overall_fee_calculator.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from web3 import Web3
+
+from models.order import Order
+from services.ethereum import create_transfer, estimate_transaction_fee, get_gas_price
+from services.withdrawer.ethereum_withdrawer import EthereumWithdrawer
+
+
+async def estimate_overall_fee(order: Order) -> int:
+    transfer_fee = await asyncio.to_thread(estimate_transfer_fee, order)
+    message_fee = await estimate_message_fee(order)
+    withdraw_fee = estimate_withdraw_fee()
+    return transfer_fee + message_fee + withdraw_fee
+
+
+def estimate_transfer_fee(order: Order) -> int:
+    dst_addr_bytes = int(order.recipient_address, 0)
+    deposit_id = Web3.to_int(order.order_id)
+    amount = Web3.to_int(order.get_int_amount())
+
+    unsent_tx, signed_tx = create_transfer(deposit_id, dst_addr_bytes, amount)
+
+    return estimate_transaction_fee(unsent_tx)
+
+
+def estimate_withdraw_fee() -> int:
+    """
+    Due to the deposit does not exist on ethereum at this point,
+    we cannot estimate the gas fee of the withdrawal transaction
+    So we will use fixed values for the gas
+    """
+    eth_withdrawal = 86139
+    return eth_withdrawal * get_gas_price()
+
+
+async def estimate_message_fee(order: Order) -> int:
+    return await EthereumWithdrawer.estimate_withdraw_fallback_message_fee(order.order_id,
+                                                                           order.recipient_address,
+                                                                           order.get_int_amount())

--- a/mm-bot/src/services/overall_fee_calculator.py
+++ b/mm-bot/src/services/overall_fee_calculator.py
@@ -37,8 +37,8 @@ def estimate_yab_withdraw_fee() -> int:
     we cannot estimate the gas fee of the withdrawal transaction
     So we will use fixed values for the gas
     """
-    eth_withdrawal = 86139
-    return eth_withdrawal * get_gas_price()
+    eth_withdrawal_gas = 86139  # TODO this is a fixed value, if the contract changes, this should be updated
+    return eth_withdrawal_gas * get_gas_price()
 
 
 async def estimate_message_fee(order: Order) -> int:

--- a/mm-bot/src/services/overall_fee_calculator.py
+++ b/mm-bot/src/services/overall_fee_calculator.py
@@ -8,6 +8,13 @@ from services.withdrawer.ethereum_withdrawer import EthereumWithdrawer
 
 
 async def estimate_overall_fee(order: Order) -> int:
+    """
+    Operational cost per order done by the market maker.
+    This includes:
+        calling the transfer (from YABTransfer) +
+        withdraw (from YABTransfer) +
+        msg fee paid to Starknet (when calling withdraw)
+    """
     transfer_fee = await asyncio.to_thread(estimate_transfer_fee, order)
     message_fee = await estimate_message_fee(order)
     withdraw_fee = estimate_yab_withdraw_fee()

--- a/mm-bot/src/services/starknet.py
+++ b/mm-bot/src/services/starknet.py
@@ -141,12 +141,7 @@ def parse_u256_from_double_u128(low, high) -> int:
 
 
 def get_fee(event) -> int:
-    # fee_threshold = 0.0001 * event.data[3]
-    # if event.data[5] < fee_threshold:
-    #     logger.info(f"[-] Order {event.data[0]} has a fee too low to process ({event.data[5]} < {fee_threshold}). Skipping")
-    #     return -1
-    # return event.data[5]
-    return 0
+    return parse_u256_from_double_u128(event.data[5], event.data[6])
 
 
 @use_async_fallback(rpc_nodes, logger, "Failed to get latest block")


### PR DESCRIPTION
# Changes
- Add `fee` to Order model.
- Add `overall_fee_calculator`: It calculates the overall fee. It is a separated file due to it uses methods from different classes. 
- Parse `fee` from event[5] and event[6] data elements.
- If the setOrder fee is not enough to pay all bot fees, the order is dropped.