### PR TITLE
Upgradeable ETH contract

### DIFF
--- a/contracts/solidity/src/YABTransfer.sol
+++ b/contracts/solidity/src/YABTransfer.sol
@@ -17,7 +17,6 @@ contract YABTransfer is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
     mapping(bytes32 => TransferInfo) public transfers;
     address private _marketMaker;
-
     IStarknetMessaging private _snMessaging;
     uint256 private _snEscrowAddress;
     uint256 private _snEscrowWithdrawSelector;


### PR DESCRIPTION
## Description
This PR implements #93.

The [OpenZeppelin upgradeable UUPS](https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable) is applied to the `YABTransfer.sol` contract. As a result, modifications were necessary in the `Deploy.s.sol` script because the deployment process changed.

In the deploy script, we deploy the `ERC1967Proxy` and `YABTransfer`.

A new command `make ethereum-upgrade` and script, `Upgrade.s.sol`, have been added to deploy the new YABTransfer, and to performe the upgrade of the smart contract via its proxy.