### PR TITLE
Upgradeable SN contract

### DIFF
--- a/contracts/cairo/src/lib.cairo
+++ b/contracts/cairo/src/lib.cairo
@@ -16,7 +16,6 @@ mod mocks {
 #[cfg(test)]
 mod tests {
     mod test_escrow;
-
     mod utils {
         mod constants;
     }


### PR DESCRIPTION
## Description

This PR implements #92 ,
It makes the SN contract (Escrow) upgradeable, by using starknet's 'upgrade' syscall, changing the smart contract's Class Hash, without the need for a proxy contract

#### Escrow.cairo
- Implement [Upgradeable from OZ](https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.8.0/src/upgrades/upgradeable.cairo) to `Escrow.cairo` contract.
- Implement [Ownable](https://docs.openzeppelin.com/contracts-cairo/0.8.0/access#ownership_and_ownable) from OZ to `Escrow.cairo` contract.
- Add some upgradeable tests

#### Scripts
- Add `upgrade.sh` for simple `Escrow.cairo` upgrading.

#### README
- Add section explaining how to use the `make starknet-upgrade` command in the Makefile
