### PR TITLE
fix: change order or variable setting, following CEI pattern

### DIFF
--- a/contracts/cairo/src/escrow.cairo
+++ b/contracts/cairo/src/escrow.cairo
@@ -165,6 +165,7 @@ mod Escrow {
             self.orders_pending.write(order_id, true);
             self.orders_senders.write(order_id, get_caller_address());
             self.orders_timestamps.write(order_id, get_block_timestamp());
+            self.current_order_id.write(order_id + 1);
 
             dispatcher.transferFrom(get_caller_address(), get_contract_address(), payment_amount);
 
@@ -178,7 +179,6 @@ mod Escrow {
                     }
                 );
 
-            self.current_order_id.write(order_id + 1);
             order_id
         }
 


### PR DESCRIPTION
Small change but [CEI Pattern](https://docs.soliditylang.org/en/v0.5.11/security-considerations.html#re-entrancy) isa big help against re-entrancy attacks.
Checks must be made first (asserts, etc).
Effects after this (changing contract variables, etc)
Interactions at the end (transfers of funds, etc).

Otherwise, receptors of interactions could be smart contracts that call again the same smart contract, and if the Effects have not been made, the function will execute again without having updated variables.

For example, before the fix in this PR, the receptor of funds could be a Smart Contract that calls withdraw again, and as the current_order_id was not updated in perspective of this second call, the risk of retrieving these funds again is opened.