### PR TITLE
docs: improve mm deploy instructions

### DIFF
--- a/docs/mm_bot/deploy.md
+++ b/docs/mm_bot/deploy.md
@@ -1,18 +1,15 @@
 # Deploy Guide
 
 ## Prerequisites
-- Python v3.10 or higher
-- pip
-- Postgres (Native or Docker)
+- [Python v3.10 or higher](https://www.python.org/downloads/)
+- [pip](https://pip.pypa.io/en/stable/installation/)
+- Postgres ([Local](https://www.postgresql.org/) or [Docker](https://hub.docker.com/_/postgres))
+- [pyenv](https://github.com/pyenv/pyenv) (Optional)
 
 ## Setup
 ### Installation
-
-```bash
-pip install -r requirements.txt
-```
 #### Virtual Environment
-If you want to use a virtual environment, you can use the following command:
+Create the virtual environment using the following command:
 
 ```bash
 make create_python_venv
@@ -23,6 +20,51 @@ To run the virtual environment, you can use the following command:
 source venv/bin/activate
 ```
 
+#### Dependencies
+To install the dependencies, you can use the following command:
+
+```bash
+make deps
+```
+
+### Database Setup
+#### Create Database Container
+This Bot uses a Postgres database. You can either install Postgres locally or use Docker (recommended for development environment). 
+
+If you use Docker, you can use the following command to start a Postgres container:
+```bash
+make create_db container=<container> user=<user> password=<pwd> database=<db_name>
+```
+
+| Variable  | Description                                                                           |
+|-----------|---------------------------------------------------------------------------------------|
+| container | The name of the docker container. If not provided, the default value is `mm-bot`      |
+| user      | The user to create. If not provided, the default value is `user`                      |
+| password  | The password for the user. If not provided, the default value is `123123123`          |
+| database  | The name of the database to create. If not provided, the default value is `mm-bot-db` |
+
+This container will have a database called `<db_name>`, by default it is `mm-bot-db`.
+
+#### Run Database Container
+If you want to run or re-run the database container, you can use the following command:
+```bash
+make start_db container=<container>
+```
+
+| Variable  | Description                                                                           |
+|-----------|---------------------------------------------------------------------------------------|
+| container | The name of the docker container. If not provided, the default value is `mm-bot`      |
+
+#### Stop Database Container
+If you want to stop the database container, you can use the following command:
+```bash
+make stop_db container=<container>
+```
+
+| Variable  | Description                                                                           |
+|-----------|---------------------------------------------------------------------------------------|
+| container | The name of the docker container. If not provided, the default value is `mm-bot`      |
+
 ### Environment Variables
 This API uses environment variables to configure the application. You can create a `.env` file in the root of the project to set the environment variables.
 
@@ -32,60 +74,35 @@ To create your own `.env` file run the following command:
 make create_env
 ```
 
-The following environment variables are used:
+The following table describes each environment variable:
 
-    ENVIRONMENT=<dev|prod>
-    ETHEREUM_RPC=<ethereum_rpc_url>
-    STARKNET_RPC=<starknet_rpc_url>
-    ETH_FALLBACK_RPC_URL=<ethereum_fallback_rpc_url>
-    SN_FALLBACK_RPC_URL=<starknet_fallback_rpc_url>
-    ETHEREUM_CONTRACT_ADDRESS=<ethereum_contract_address>
-    STARKNET_CONTRACT_ADDRESS=<starknet_contract_address>
-    ETHEREUM_PRIVATE_KEY=<ethereum_private_key>
-    STARKNET_WALLET_ADDRESS=<starknet_wallet_address>
-    STARKNET_PRIVATE_KEY=<starknet_private_key>
-    HERODOTUS_API_KEY=<herodotus_api_key>
-    POSTGRES_HOST=<postgres_host>
-    POSTGRES_USER=<postgres_user>
-    POSTGRES_PASSWORD=<postgres_password>
-    POSTGRES_DATABASE=<postgres_db>
-    LOGGING_LEVEL=<DEBUG|INFO|WARNING|ERROR|CRITICAL>
-    LOGGING_DIRECTORY=<logging_directory to save the logs in prod mode>
-    PAYMENT_CLAIMER=<herodotus|ethereum>
+| Variable                  | Description                                                                                                       |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------|
+| ENVIRONMENT               | The environment of the application. It can be `dev` or `prod`                                                     |
+| ETHEREUM_CHAIN_ID         | The chain ID of the Ethereum network. It can be `1` for Mainnet, 11155111 for Sepolia                             |
+| STARKNET_CHAIN_ID         | The chain ID of the Starknet network. It can be `SN_MAINNET` for Mainnet, `SN_SEPOLIA` for Sepolia                |
+| ETHEREUM_RPC              | The URL of the Ethereum RPC. You can get one at [Blast](https://blastapi.io/) or [Infure](https://www.infura.io/) |
+| STARKNET_RPC              | The URL of the Starknet RPC. You can get one at [Blast](https://blastapi.io/) or [Infure](https://www.infura.io/) |
+| ZKSYNC_RPC                | The URL of the ZkSync RPC. You can get one at [Blast](https://blastapi.io/)                                       |
+| ETH_FALLBACK_RPC_URL      | The URL of the Ethereum RPC fallback                                                                              |
+| SN_FALLBACK_RPC_URL       | The URL of the Starknet RPC fallback                                                                              |
+| ZKSYNC_FALLBACK_RPC_URL   | The URL of the ZkSync RPC fallback                                                                                | 
+| ETHEREUM_CONTRACT_ADDRESS | The address of the Payment Registry                                                                               |
+| STARKNET_CONTRACT_ADDRESS | The address of the Starknet Escrow                                                                                |
+| ZKS_CONTRACT_ADDRESS      | The address of the ZkSync Escrow                                                                                  |
+| ETHEREUM_PRIVATE_KEY      | The private key of Market Maker on Ethereum                                                                       |
+| STARKNET_WALLET_ADDRESS   | The wallet address of Market Maker on Starknet                                                                    |
+| STARKNET_PRIVATE_KEY      | The private key of Market Maker on Starknet                                                                       |
+| HERODOTUS_API_KEY         | (Optional) The API key of Herodotus. Needed if using herodotus payment claimer                                    |
+| POSTGRES_HOST             | The host of the Postgres database                                                                                 |
+| POSTGRES_USER             | The user of the Postgres database                                                                                 |
+| POSTGRES_PASSWORD         | The password of the Postgres database                                                                             |
+| POSTGRES_DATABASE         | The name of the Postgres database                                                                                 |
+| LOGGING_LEVEL             | The level of logging. It can be `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`                                |
+| LOGGING_DIRECTORY         | The directory to save the logs in prod `mode`. Only needed in `prod` mode                                         |
+| PAYMENT_CLAIMER           | The payment claimer. It can be `herodotus` or `ethereum`                                                          |
 
-
-There is a example file called `.env.example` in the root of the project. 
-
-### Database Setup
-#### Create Database Container
-This Bot uses a Postgres database. You can either install Postgres natively or use Docker (recommended for development environment). 
-If you use Docker, you can use the following command to start a Postgres container:
-```bash
-make create_db container=<container> user=<user> password=<pwd> database=<db_name>
-```
-    Where:
-    - container:    the name of the docker container. If not provided, the default value is 'postgres'
-    - user:         the user to create. If not provided, the default value is 'user'
-    - password:     the password for the user. If not provided, the default value is '123123123'
-    - database:     the name of the database to create. If not provided, the default value is 'mm-bot'
-
-This container will have a database called `<database>`, by default it is `mm-bot`.
-
-#### Run Database Container
-If you want to run or re-run the database container, you can use the following command:
-```bash
-make run_db container=<container>
-```
-    Where:
-    - container:    the name of the docker container. If not provided, the default value is 'postgres'
-
-#### Stop Database Container
-If you want to stop the database container, you can use the following command:
-```bash
-make stop_db container=<container>
-```
-    Where:
-    - container:    the name of the docker container. If not provided, the default value is 'postgres'
+There is an example file called `.env.example` in the root of the project. 
 
 #### Database Population
 To create the tables, you can use the following command:
@@ -98,7 +115,7 @@ You must run schema.sql into the database to create the tables. You can use pgAd
 To start the Bot, you can use the following command:
 
 ```bash
-python3 src/main.py
+make run
 ```
 
 ## Test [TODO]

--- a/docs/mm_bot/deploy.md
+++ b/docs/mm_bot/deploy.md
@@ -1,7 +1,7 @@
 # Deploy Guide
 
 ## Prerequisites
-- [Python v3.10 or higher](https://www.python.org/downloads/)
+- [Python v3.10](https://www.python.org/downloads/)
 - [pip](https://pip.pypa.io/en/stable/installation/)
 - Postgres ([Local](https://www.postgresql.org/) or [Docker](https://hub.docker.com/_/postgres))
 - [pyenv](https://github.com/pyenv/pyenv) (Optional)

--- a/mm-bot/Makefile
+++ b/mm-bot/Makefile
@@ -1,3 +1,5 @@
+.PHONE: deps run create_env create_python_venv start_db stop_db create_db
+
 # Database variables
 container = mm-bot
 user = user
@@ -6,6 +8,11 @@ database = mm-bot-db
 
 
 # Application Commands
+deps:
+    @echo "Installing dependencies..."
+    @. venv/bin/activate && pip install -r requirements.txt
+    @echo "Dependencies installed successfully!"
+
 run:
 	@echo "Running application..."
 	@. venv/bin/activate && python3 src/main.py
@@ -22,11 +29,11 @@ create_python_venv:
 
 # Database Commands
 start_db:
-	@if [ "$(container)" = "postgres" ]; then echo "Using default container name: postgres."; fi
+	@if [ "$(container)" = "mm-bot" ]; then echo "Using default container name: mm-bot."; fi
 	docker start $(container)
 
 stop_db:
-	@if [ "$(container)" = "postgres" ]; then echo "Using default container name: postgres."; fi
+	@if [ "$(container)" = "mm-bot" ]; then echo "Using default container name: mm-bot."; fi
 	docker stop $(container)
 
 create_db:

--- a/mm-bot/README.md
+++ b/mm-bot/README.md
@@ -1,19 +1,16 @@
 # Market Maker Bot
 Market Maker Bot is a bot that provides liquidity to the Yet Another Bridge (YAB).
 
-# Prerequisites
-- Python v3.10 or higher
-- pip
-- Postgres (Native or Docker)
+## Prerequisites
+- [Python v3.10](https://www.python.org/downloads/)
+- [pip](https://pip.pypa.io/en/stable/installation/)
+- Postgres ([Local](https://www.postgresql.org/) or [Docker](https://hub.docker.com/_/postgres))
+- [pyenv](https://github.com/pyenv/pyenv) (Optional)
 
-# Setup
-## Installation
-
-```bash
-pip install -r requirements.txt
-```
-### Virtual Environment
-If you want to use a virtual environment, you can use the following command:
+## Setup
+### Installation
+#### Virtual Environment
+Create the virtual environment using the following command:
 
 ```bash
 make create_python_venv
@@ -24,7 +21,52 @@ To run the virtual environment, you can use the following command:
 source venv/bin/activate
 ```
 
-## Environment Variables
+#### Dependencies
+To install the dependencies, you can use the following command:
+
+```bash
+make deps
+```
+
+### Database Setup
+#### Create Database Container
+This Bot uses a Postgres database. You can either install Postgres locally or use Docker (recommended for development environment). 
+
+If you use Docker, you can use the following command to start a Postgres container:
+```bash
+make create_db container=<container> user=<user> password=<pwd> database=<db_name>
+```
+
+| Variable  | Description                                                                           |
+|-----------|---------------------------------------------------------------------------------------|
+| container | The name of the docker container. If not provided, the default value is `mm-bot`      |
+| user      | The user to create. If not provided, the default value is `user`                      |
+| password  | The password for the user. If not provided, the default value is `123123123`          |
+| database  | The name of the database to create. If not provided, the default value is `mm-bot-db` |
+
+This container will have a database called `<db_name>`, by default it is `mm-bot-db`.
+
+#### Run Database Container
+If you want to run or re-run the database container, you can use the following command:
+```bash
+make start_db container=<container>
+```
+
+| Variable  | Description                                                                           |
+|-----------|---------------------------------------------------------------------------------------|
+| container | The name of the docker container. If not provided, the default value is `mm-bot`      |
+
+#### Stop Database Container
+If you want to stop the database container, you can use the following command:
+```bash
+make stop_db container=<container>
+```
+
+| Variable  | Description                                                                           |
+|-----------|---------------------------------------------------------------------------------------|
+| container | The name of the docker container. If not provided, the default value is `mm-bot`      |
+
+### Environment Variables
 This API uses environment variables to configure the application. You can create a `.env` file in the root of the project to set the environment variables.
 
 To create your own `.env` file run the following command:
@@ -33,76 +75,51 @@ To create your own `.env` file run the following command:
 make create_env
 ```
 
-The following environment variables are used:
+The following table describes each environment variable:
 
-    ENVIRONMENT=<dev|prod>
-    ETHEREUM_RPC=<ethereum_rpc_url>
-    STARKNET_RPC=<starknet_rpc_url>
-    ETHEREUM_FALLBACK_RPC=<ethereum_fallback_rpc_url>
-    STARKNET_FALLBACK_RPC=<starknet_fallback_rpc_url>
-    ETHEREUM_CONTRACT_ADDRESS=<ethereum_contract_address>
-    STARKNET_CONTRACT_ADDRESS=<starknet_contract_address>
-    ETHEREUM_PRIVATE_KEY=<ethereum_private_key>
-    STARKNET_WALLET_ADDRESS=<starknet_wallet_address>
-    STARKNET_PRIVATE_KEY=<starknet_private_key>
-    HERODOTUS_API_KEY=<herodotus_api_key>
-    POSTGRES_HOST=<postgres_host>
-    POSTGRES_USER=<postgres_user>
-    POSTGRES_PASSWORD=<postgres_password>
-    POSTGRES_DATABASE=<postgres_db>
-    LOGGING_LEVEL=<DEBUG|INFO|WARNING|ERROR|CRITICAL>
-    LOGGING_DIRECTORY=<logging_directory to save the logs in prod mode>
-    PAYMENT_CLAIMER=<herodotus|ethereum>
+| Variable                  | Description                                                                                                       |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------|
+| ENVIRONMENT               | The environment of the application. It can be `dev` or `prod`                                                     |
+| ETHEREUM_CHAIN_ID         | The chain ID of the Ethereum network. It can be `1` for Mainnet, 11155111 for Sepolia                             |
+| STARKNET_CHAIN_ID         | The chain ID of the Starknet network. It can be `SN_MAINNET` for Mainnet, `SN_SEPOLIA` for Sepolia                |
+| ETHEREUM_RPC              | The URL of the Ethereum RPC. You can get one at [Blast](https://blastapi.io/) or [Infure](https://www.infura.io/) |
+| STARKNET_RPC              | The URL of the Starknet RPC. You can get one at [Blast](https://blastapi.io/) or [Infure](https://www.infura.io/) |
+| ZKSYNC_RPC                | The URL of the ZkSync RPC. You can get one at [Blast](https://blastapi.io/)                                       |
+| ETH_FALLBACK_RPC_URL      | The URL of the Ethereum RPC fallback                                                                              |
+| SN_FALLBACK_RPC_URL       | The URL of the Starknet RPC fallback                                                                              |
+| ZKSYNC_FALLBACK_RPC_URL   | The URL of the ZkSync RPC fallback                                                                                | 
+| ETHEREUM_CONTRACT_ADDRESS | The address of the Payment Registry                                                                               |
+| STARKNET_CONTRACT_ADDRESS | The address of the Starknet Escrow                                                                                |
+| ZKS_CONTRACT_ADDRESS      | The address of the ZkSync Escrow                                                                                  |
+| ETHEREUM_PRIVATE_KEY      | The private key of Market Maker on Ethereum                                                                       |
+| STARKNET_WALLET_ADDRESS   | The wallet address of Market Maker on Starknet                                                                    |
+| STARKNET_PRIVATE_KEY      | The private key of Market Maker on Starknet                                                                       |
+| HERODOTUS_API_KEY         | (Optional) The API key of Herodotus. Needed if using herodotus payment claimer                                    |
+| POSTGRES_HOST             | The host of the Postgres database                                                                                 |
+| POSTGRES_USER             | The user of the Postgres database                                                                                 |
+| POSTGRES_PASSWORD         | The password of the Postgres database                                                                             |
+| POSTGRES_DATABASE         | The name of the Postgres database                                                                                 |
+| LOGGING_LEVEL             | The level of logging. It can be `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`                                |
+| LOGGING_DIRECTORY         | The directory to save the logs in prod `mode`. Only needed in `prod` mode                                         |
+| PAYMENT_CLAIMER           | The payment claimer. It can be `herodotus` or `ethereum`                                                          |
 
+There is an example file called `.env.example` in the root of the project. 
 
-There is a example file called `.env.example` in the root of the project. 
-
-## Database Setup
-### Create Database Container
-This Bot uses a Postgres database. You can either install Postgres natively or use Docker (recommended for development environment). 
-If you use Docker, you can use the following command to start a Postgres container:
-```bash
-make create_db container=<container> user=<user> password=<pwd> database=<db_name>
-```
-    Where:
-    - container:    the name of the docker container. If not provided, the default value is 'postgres'
-    - user:         the user to create. If not provided, the default value is 'user'
-    - password:     the password for the user. If not provided, the default value is '123123123'
-    - database:     the name of the database to create. If not provided, the default value is 'mm-bot'
-
-This container will have a database called `<database>`, by default it is `mm-bot`.
-
-### Run Database Container
-If you want to run or re-run the database container, you can use the following command:
-```bash
-make run_db container=<container>
-```
-    Where:
-    - container:    the name of the docker container. If not provided, the default value is 'postgres'
-
-### Stop Database Container
-If you want to stop the database container, you can use the following command:
-```bash
-make stop_db container=<container>
-```
-    Where:
-    - container:    the name of the docker container. If not provided, the default value is 'postgres'
-
-### Database Population
+#### Database Population
 To create the tables, you can use the following command:
 ```bash
 TODO
 ```
 You must run schema.sql into the database to create the tables. You can use pgAdmin or any other tool to run the script.
 
-# Development
+## Development
 To start the Bot, you can use the following command:
 
 ```bash
-python3 src/main.py
+make run
 ```
 
-# Test [TODO]
+## Test [TODO]
 To run the tests, you can use the following command:
 
 ```bash


### PR DESCRIPTION
# Changes
## Docs
- Set python version to 3.10 in prerequisites
- Use tables instead of code block for environment variables

## Makefile
- Add `deps` target to install dependencies inside the virtual env
- Set .PHONY
- Use correct variables names and vlaues