### PR TITLE
fix: add origin_network to Error model

### DIFF
--- a/mm-bot/src/models/error.py
+++ b/mm-bot/src/models/error.py
@@ -1,16 +1,26 @@
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, ForeignKey, String, DateTime
+from sqlalchemy import Column, Integer, ForeignKeyConstraint, String, DateTime, Enum
 from sqlalchemy.orm import relationship, Mapped
 
 from config.database_config import Base
+from models.network import Network
 from models.order import Order
 
 
 class Error(Base):
     __tablename__ = "error"
     id: int = Column(Integer, primary_key=True, nullable=False)
-    order_id: int = Column(Integer, ForeignKey("orders.order_id"), nullable=False)
+    order_id: int = Column(Integer, nullable=False)
+    origin_network: Network = Column(Enum(Network), nullable=False)
     order: Mapped[Order] = relationship("Order")
     message: str = Column(String, nullable=False)
     created_at: datetime = Column(DateTime, nullable=False, server_default="clock_timestamp()")
+
+    # Set order_id and origin_network as composite foreign key
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["order_id", "origin_network"],
+            ["orders.order_id", "orders.origin_network"]
+        ),
+    )

--- a/mm-bot/src/services/order_service.py
+++ b/mm-bot/src/services/order_service.py
@@ -141,7 +141,7 @@ class OrderService:
         :param error_message: the error message to store in the database
         """
         order = self.set_failed(order, True)
-        error = Error(order_id=order.order_id, message=error_message)
+        error = Error(order_id=order.order_id, origin_network=order.origin_network, message=error_message)
         self.error_dao.create_error(error)
         return order
 


### PR DESCRIPTION
# Changelist
- Add origin_network to Error model
- Set order_id+origin_network as composite foreign key
- Set origin_network on error creation