### PR TITLE
fix(mm): add tabs to deps recipe

### DIFF
--- a/mm-bot/Makefile
+++ b/mm-bot/Makefile
@@ -9,9 +9,9 @@ database = mm-bot-db
 
 # Application Commands
 deps:
-    @echo "Installing dependencies..."
-    @. venv/bin/activate && pip install -r requirements.txt
-    @echo "Dependencies installed successfully!"
+	@echo "Installing dependencies..."
+	@. venv/bin/activate && pip install -r requirements.txt
+	@echo "Dependencies installed successfully!"
 
 run:
 	@echo "Running application..."


### PR DESCRIPTION
## Context
- There was an error in the Makefile due to using whitespaces instead of tabs in the deps recipe.
## Description
- This fix replaces the 4 whitespaces with tabs in the deps recipe.
## Changes in the codebase
- Replaced the 4 whitespaces with tabs in the deps recipe.