### PR TITLE
chore(mm): update web3 version from 6.5.0 to 6.10.0

### DIFF
--- a/mm-bot/requirements.txt
+++ b/mm-bot/requirements.txt
@@ -1,7 +1,7 @@
 python-dotenv==1.0.0
 Requests==2.31.0
 starknet_py==0.19.0-alpha
-web3==6.5.0
+web3==6.10.0
 SQLAlchemy==2.0.23
 psycopg2-binary==2.9.9
 schedule==1.2.1


### PR DESCRIPTION
## Context
- Web3 library version needed to be updated from 6.5.0 to 6.10.0 due to conflicting dependencies with zksync2 1.1.0.

## Changes in the codebase
- Changed web3 library version from 6.5.0 to 6.10.0 in requirements.txt.