### PR TITLE
chore(mm-bot): add indexes to database

### DIFF
--- a/mm-bot/resources/schema.sql
+++ b/mm-bot/resources/schema.sql
@@ -45,3 +45,12 @@ CREATE TABLE IF NOT EXISTS error
 
     FOREIGN KEY (order_id, origin_network) REFERENCES orders (order_id, origin_network) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS orders_transferred_at_idx ON public.orders USING btree (transferred_at);
+CREATE INDEX IF NOT EXISTS orders_amount_idx ON public.orders USING btree (amount);
+CREATE INDEX IF NOT EXISTS orders_origin_network_idx ON public.orders USING btree (origin_network);
+CREATE INDEX IF NOT EXISTS orders_recipient_address_idx ON public.orders USING btree (recipient_address);
+CREATE INDEX IF NOT EXISTS orders_order_id_idx ON public.orders USING btree (order_id);
+CREATE INDEX IF NOT EXISTS orders_status_idx ON public.orders USING btree (status);
+CREATE INDEX IF NOT EXISTS orders_created_at_idx ON public.orders USING btree (created_at);
+CREATE INDEX IF NOT EXISTS orders_completed_at_idx ON public.orders USING btree (completed_at);


### PR DESCRIPTION
## Description
- Add indexes to database to improve performance of sorted columns.
## Results
- Queries in replica improved speed performance up to 2x.
### Before Index
**In primary:**

``` Sort  (cost=15.09..15.57 rows=190 width=389) (actual time=0.108..0.119 rows=190 loops=1)
   Sort Key: amount
   Sort Method: quicksort  Memory: 69kB
   Buffers: shared hit=6
   ->  Seq Scan on orders  (cost=0.00..7.90 rows=190 width=389) (actual time=0.011..0.035 rows=190 loops=1)
         Buffers: shared hit=6
 Planning Time: 0.059 ms
 Execution Time: 0.146 ms
(8 rows)
```

**In replica:**

```
 Sort  (cost=15.09..15.57 rows=190 width=389) (actual time=0.151..0.162 rows=190 loops=1)
   Sort Key: amount
   Sort Method: quicksort  Memory: 69kB
   Buffers: shared hit=9
   ->  Seq Scan on orders  (cost=0.00..7.90 rows=190 width=389) (actual time=0.006..0.035 rows=190 loops=1)
         Buffers: shared hit=6
 Planning:
   Buffers: shared hit=156 read=2
 Planning Time: 0.498 ms
 Execution Time: 0.212 ms
(10 rows)
```
### After Index
**In primary:**
```
 Sort  (cost=15.09..15.57 rows=190 width=389) (actual time=0.106..0.117 rows=190 loops=1)
   Sort Key: amount
   Sort Method: quicksort  Memory: 69kB
   Buffers: shared hit=6
   ->  Seq Scan on orders  (cost=0.00..7.90 rows=190 width=389) (actual time=0.007..0.031 rows=190 loops=1)
         Buffers: shared hit=6
 Planning:
   Buffers: shared hit=15 read=1
 Planning Time: 0.203 ms
 Execution Time: 0.142 ms
(10 rows)
```

**In replica:**
```
 Sort  (cost=15.09..15.57 rows=190 width=389) (actual time=0.108..0.119 rows=190 loops=1)
   Sort Key: amount
   Sort Method: quicksort  Memory: 69kB
   Buffers: shared hit=6
   ->  Seq Scan on orders  (cost=0.00..7.90 rows=190 width=389) (actual time=0.006..0.029 rows=190 loops=1)
         Buffers: shared hit=6
 Planning:
   Buffers: shared hit=21
 Planning Time: 0.171 ms
 Execution Time: 0.144 ms
(10 rows)
```