### PR TITLE
chore(mm bot): save from address from set order events

### DIFF
--- a/mm-bot/requirements.txt
+++ b/mm-bot/requirements.txt
@@ -6,3 +6,4 @@ SQLAlchemy==2.0.23
 psycopg2-binary==2.9.9
 schedule==1.2.1
 zksync2==1.1.0
+hexbytes==1.2.0

--- a/mm-bot/resources/schema.sql
+++ b/mm-bot/resources/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS orders
     order_id          INT            NOT NULL,
     origin_network    VARCHAR(32)    NOT NULL,
 
-    from_address      VARCHAR(64)    NOT NULL, -- 64 chars to allow Starknet and zkSync compatibility
+    from_address      VARCHAR(66)    NOT NULL, -- 66 chars to allow Starknet and zkSync compatibility
     recipient_address VARCHAR(42)    NOT NULL, -- 0x + 40 bytes
     amount            NUMERIC(78, 0) NOT NULL, -- uint 256
     fee               NUMERIC(78, 0) NOT NULL, -- uint 256

--- a/mm-bot/resources/schema.sql
+++ b/mm-bot/resources/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS orders
     order_id          INT            NOT NULL,
     origin_network    VARCHAR(32)    NOT NULL,
 
+    from_address      VARCHAR(64)    NOT NULL, -- 64 chars to allow Starknet and zkSync compatibility
     recipient_address VARCHAR(42)    NOT NULL, -- 0x + 40 bytes
     amount            NUMERIC(78, 0) NOT NULL, -- uint 256
     fee               NUMERIC(78, 0) NOT NULL, -- uint 256

--- a/mm-bot/src/models/order.py
+++ b/mm-bot/src/models/order.py
@@ -57,8 +57,8 @@ class Order(Base):
     def from_set_order_event(set_order_event: SetOrderEvent):
         return Order(
             order_id=set_order_event.order_id,
-            from_address=set_order_event.from_address,
             origin_network=set_order_event.origin_network,
+            from_address=set_order_event.from_address,
             recipient_address=set_order_event.recipient_address,
             amount=set_order_event.amount,
             fee=set_order_event.fee,

--- a/mm-bot/src/models/order.py
+++ b/mm-bot/src/models/order.py
@@ -15,6 +15,7 @@ class Order(Base):
     order_id: int = Column(Integer, primary_key=True, nullable=False)
     origin_network: Network = Column(Enum(Network), primary_key=True, nullable=False)
 
+    from_address: str = Column(String(64), nullable=False)
     recipient_address: str = Column(String(42), nullable=False)
     amount: decimal = Column(Numeric(78, 0), nullable=False)
     fee: decimal = Column(Numeric(78, 0), nullable=False)
@@ -56,6 +57,7 @@ class Order(Base):
     def from_set_order_event(set_order_event: SetOrderEvent):
         return Order(
             order_id=set_order_event.order_id,
+            from_address=set_order_event.from_address,
             origin_network=set_order_event.origin_network,
             recipient_address=set_order_event.recipient_address,
             amount=set_order_event.amount,

--- a/mm-bot/src/models/set_order_event.py
+++ b/mm-bot/src/models/set_order_event.py
@@ -8,8 +8,8 @@ class SetOrderEvent:
 
     def __init__(self,
                  order_id,
-                 from_address,
                  origin_network,
+                 from_address,
                  set_order_tx_hash,
                  recipient_address,
                  amount,
@@ -17,8 +17,8 @@ class SetOrderEvent:
                  block_number,
                  is_used=False):
         self.order_id = order_id
-        self.from_address = from_address
         self.origin_network = origin_network
+        self.from_address = from_address
         self.set_order_tx_hash = set_order_tx_hash
         self.recipient_address = recipient_address
         self.amount = amount
@@ -47,8 +47,8 @@ class SetOrderEvent:
                                           Network.STARKNET.value)
         return SetOrderEvent(
             order_id=order_id,
-            from_address=event.from_address,
             origin_network=Network.STARKNET,
+            from_address=event.from_address,
             set_order_tx_hash=set_order_tx_hash,
             recipient_address=recipient_address,
             amount=amount,
@@ -84,8 +84,8 @@ class SetOrderEvent:
 
         return SetOrderEvent(
             order_id=order_id,
-            from_address=log['from_address'],
             origin_network=Network.ZKSYNC,
+            from_address=log['from_address'],
             set_order_tx_hash=set_order_tx_hash,
             recipient_address=recipient_address,
             amount=amount,

--- a/mm-bot/src/models/set_order_event.py
+++ b/mm-bot/src/models/set_order_event.py
@@ -99,9 +99,9 @@ class SetOrderEvent:
         return high << 128 | low
 
     def __str__(self):
-        return f"Order: {self.order_id} - From Address: {self.from_address} - Origin: {self.origin_network} - Amount:" \
-               f" {self.amount} - Fee: {self.fee} - Recipient: {self.recipient_address} - Is used: {self.is_used} -" \
-               f" Block: {self.block_number}"
+        return f"Order: {self.order_id} - Origin: {self.origin_network} - From Address: {self.from_address} - "\
+               f"Amount: {self.amount} - Fee: {self.fee} - Recipient: {self.recipient_address} - " \
+               f"Is used: {self.is_used} - Block: {self.block_number}"
 
     def __repr__(self):
         return self.__str__()

--- a/mm-bot/src/models/set_order_event.py
+++ b/mm-bot/src/models/set_order_event.py
@@ -99,7 +99,7 @@ class SetOrderEvent:
         return high << 128 | low
 
     def __str__(self):
-        return f"Order: {self.order_id} - Origin: {self.origin_network} - From Address: {self.from_address} - "\
+        return f"Order: {self.order_id} - Origin: {self.origin_network} - From: {self.from_address} - "\
                f"Amount: {self.amount} - Fee: {self.fee} - Recipient: {self.recipient_address} - " \
                f"Is used: {self.is_used} - Block: {self.block_number}"
 

--- a/mm-bot/src/models/set_order_event.py
+++ b/mm-bot/src/models/set_order_event.py
@@ -8,6 +8,7 @@ class SetOrderEvent:
 
     def __init__(self,
                  order_id,
+                 from_address,
                  origin_network,
                  set_order_tx_hash,
                  recipient_address,
@@ -16,6 +17,7 @@ class SetOrderEvent:
                  block_number,
                  is_used=False):
         self.order_id = order_id
+        self.from_address = from_address
         self.origin_network = origin_network
         self.set_order_tx_hash = set_order_tx_hash
         self.recipient_address = recipient_address
@@ -28,7 +30,8 @@ class SetOrderEvent:
     async def from_starknet(event):
         """
         event = {
-            "tx_hash": "0x
+            "from_address": "0x",
+            "tx_hash": "0x",
             "block_number": 0,
             "data": [0, 0, 0, 0, 0, 0, 0]
         }
@@ -40,9 +43,11 @@ class SetOrderEvent:
         recipient_address = hex(event.data[2])
         amount = SetOrderEvent.parse_u256_from_double_u128(event.data[3], event.data[4])
         fee = SetOrderEvent.parse_u256_from_double_u128(event.data[5], event.data[6])
-        is_used = await asyncio.to_thread(ethereum.get_is_used_order, order_id, recipient_address, amount, Network.STARKNET.value)
+        is_used = await asyncio.to_thread(ethereum.get_is_used_order, order_id, recipient_address, amount,
+                                          Network.STARKNET.value)
         return SetOrderEvent(
             order_id=order_id,
+            from_address=event.from_address,
             origin_network=Network.STARKNET,
             set_order_tx_hash=set_order_tx_hash,
             recipient_address=recipient_address,
@@ -56,6 +61,7 @@ class SetOrderEvent:
     async def from_zksync(log):
         """
         log = {
+            "from_address": "0x",
             "transactionHash": "0x",
             "blockNumber": 0,
             "args": {
@@ -68,20 +74,23 @@ class SetOrderEvent:
         transactionHash: HexBytes
         recipient_address: str
         """
-        order_id = log.args.order_id
-        set_order_tx_hash = log.transactionHash
-        recipient_address = log.args.recipient_address
-        amount = log.args.amount
-        fee = log.args.fee
-        is_used = await asyncio.to_thread(ethereum.get_is_used_order, order_id, recipient_address, amount, Network.ZKSYNC.value)  # TODO change to new contract signature
+        order_id = log['args'].order_id
+        set_order_tx_hash = log['transactionHash']
+        recipient_address = log['args'].recipient_address
+        amount = log['args'].amount
+        fee = log['args'].fee
+        is_used = await asyncio.to_thread(ethereum.get_is_used_order, order_id, recipient_address, amount,
+                                          Network.ZKSYNC.value)  # TODO change to new contract signature
+
         return SetOrderEvent(
             order_id=order_id,
+            from_address=log['from_address'],
             origin_network=Network.ZKSYNC,
             set_order_tx_hash=set_order_tx_hash,
             recipient_address=recipient_address,
             amount=amount,
             fee=fee,
-            block_number=log.blockNumber,
+            block_number=log['blockNumber'],
             is_used=is_used
         )
 
@@ -90,8 +99,9 @@ class SetOrderEvent:
         return high << 128 | low
 
     def __str__(self):
-        return f"Order: {self.order_id} - Origin: {self.origin_network} - Amount: {self.amount} - Fee: {self.fee} - " \
-               f"Recipient: {self.recipient_address} - Is used: {self.is_used} - Block: {self.block_number}"
+        return f"Order: {self.order_id} - From Address: {self.from_address} - Origin: {self.origin_network} - Amount:" \
+               f" {self.amount} - Fee: {self.fee} - Recipient: {self.recipient_address} - Is used: {self.is_used} -" \
+               f" Block: {self.block_number}"
 
     def __repr__(self):
         return self.__str__()

--- a/mm-bot/src/models/zksync_log.py
+++ b/mm-bot/src/models/zksync_log.py
@@ -1,6 +1,8 @@
 from web3.types import EventData
 
 
-# EventData web3 library class doesn't have a from_address field, so we need to extend it to store it
 class ZksyncLog(EventData):
+    """
+    EventData web3 library class doesn't have a from_address field, so we need to extend it to store it
+    """
     from_address: str

--- a/mm-bot/src/models/zksync_log.py
+++ b/mm-bot/src/models/zksync_log.py
@@ -1,0 +1,6 @@
+from web3.types import EventData
+
+
+# EventData web3 library class doesn't have a from_address field, so we need to extend it to store it
+class ZksyncLog(EventData):
+    from_address: str

--- a/mm-bot/src/services/mm_full_node_client.py
+++ b/mm-bot/src/services/mm_full_node_client.py
@@ -12,6 +12,7 @@ EXCLUDE = "exclude"
 @dataclass
 class MmEvent(Event):
     tx_hash: str
+    from_address: str
     block_number: int
 
 

--- a/mm-bot/src/services/starknet.py
+++ b/mm-bot/src/services/starknet.py
@@ -91,6 +91,7 @@ async def get_order_events(from_block_number, to_block_number) -> list[SetOrderE
     transactions = await asyncio.gather(*event_tasks)
 
     # asyncio.gather() returns the results in the same order as the input list, so we can zip the two lists
+    # https://docs.python.org/3/library/asyncio-task.html#running-tasks-concurrently
     for transaction, event in zip(transactions, events):
         transaction = cast(InvokeTransaction, transaction)
         from_address = f'0x{transaction.sender_address:064x}'

--- a/mm-bot/src/services/starknet.py
+++ b/mm-bot/src/services/starknet.py
@@ -94,8 +94,7 @@ async def get_order_events(from_block_number, to_block_number) -> list[SetOrderE
     # https://docs.python.org/3/library/asyncio-task.html#running-tasks-concurrently
     for transaction, event in zip(transactions, events):
         transaction = cast(InvokeTransaction, transaction)
-        from_address = f'0x{transaction.sender_address:064x}'
-        event.from_address = from_address
+        event.from_address = f'0x{transaction.sender_address:064x}'
         order_tasks.append(asyncio.create_task(SetOrderEvent.from_starknet(event)))
 
     for order_task in order_tasks:

--- a/mm-bot/src/services/starknet.py
+++ b/mm-bot/src/services/starknet.py
@@ -85,8 +85,7 @@ async def get_order_events(from_block_number, to_block_number) -> list[SetOrderE
             break
 
     for event in events:
-        event_task = asyncio.create_task(get_transaction(event.tx_hash))
-        event_tasks.append(event_task)
+        event_tasks.append(asyncio.create_task(get_transaction(event.tx_hash)))
 
     transactions = await asyncio.gather(*event_tasks)
 

--- a/mm-bot/src/services/starknet.py
+++ b/mm-bot/src/services/starknet.py
@@ -96,10 +96,9 @@ async def get_order_events(from_block_number, to_block_number) -> list[SetOrderE
         event.from_address = f'0x{transaction.sender_address:064x}'
         order_tasks.append(asyncio.create_task(SetOrderEvent.from_starknet(event)))
 
-    for order_task in order_tasks:
-        order = await order_task
-        order_events.append(order)
-    return order_events
+    order_events = await asyncio.gather(*order_tasks)
+
+    return cast(list[SetOrderEvent], order_events)
 
 
 @use_async_fallback(rpc_nodes, logger, "Failed to get latest block number")

--- a/mm-bot/src/services/starknet.py
+++ b/mm-bot/src/services/starknet.py
@@ -91,7 +91,7 @@ async def get_order_events(from_block_number, to_block_number) -> list[SetOrderE
 
     # asyncio.gather() returns the results in the same order as the input list, so we can zip the two lists
     # https://docs.python.org/3/library/asyncio-task.html#running-tasks-concurrently
-    for transaction, event in zip(transactions, events):
+    for event, transaction in zip(events, transactions):
         transaction = cast(InvokeTransaction, transaction)
         event.from_address = f'0x{transaction.sender_address:064x}'
         order_tasks.append(asyncio.create_task(SetOrderEvent.from_starknet(event)))

--- a/mm-bot/src/services/zksync.py
+++ b/mm-bot/src/services/zksync.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import json
 import logging
 import os
@@ -8,13 +7,13 @@ from typing import cast
 from web3 import AsyncWeb3
 from web3.eth.async_eth import AsyncContract
 from web3.types import EventData
+from hexbytes import HexBytes
+
 
 from config import constants
 from models.set_order_event import SetOrderEvent
 from models.zksync_log import ZksyncLog
 from services.decorators.use_fallback import use_async_fallback
-
-from hexbytes import HexBytes
 
 # Just for keep consistency with the ethereum and starknet
 # services it won't be a class. It will be a set of functions

--- a/mm-bot/src/services/zksync.py
+++ b/mm-bot/src/services/zksync.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -10,7 +11,10 @@ from web3.types import EventData
 
 from config import constants
 from models.set_order_event import SetOrderEvent
+from models.zksync_log import ZksyncLog
 from services.decorators.use_fallback import use_async_fallback
+
+from hexbytes import HexBytes
 
 # Just for keep consistency with the ethereum and starknet
 # services it won't be a class. It will be a set of functions
@@ -65,7 +69,19 @@ async def get_set_order_events(from_block, to_block) -> list[SetOrderEvent]:
     Get set_orders events from the escrow
     """
     set_order_logs: list[EventData] = await get_set_order_logs(from_block, to_block)
+    tasks = []
+
     # Create a list of tasks to parallelize the creation of the SetOrderEvent list
-    tasks = [asyncio.create_task(SetOrderEvent.from_zksync(log)) for log in set_order_logs]
+    for log in set_order_logs:
+        transaction = await get_tx(log['transactionHash'])
+        from_address = transaction['from']
+        zksync_log = ZksyncLog(**log, from_address=from_address)
+        tasks.append(asyncio.create_task(SetOrderEvent.from_zksync(zksync_log)))
+
     set_order_events = await asyncio.gather(*tasks)
     return cast(list[SetOrderEvent], set_order_events)
+
+
+@use_async_fallback(rpc_nodes, logger, "Failed to get the tx")
+async def get_tx(tx_hash: HexBytes, rpc_node=main_rpc_node):
+    return await rpc_node.w3.eth.get_transaction(tx_hash)

--- a/mm-bot/src/services/zksync.py
+++ b/mm-bot/src/services/zksync.py
@@ -78,7 +78,7 @@ async def get_set_order_events(from_block, to_block) -> list[SetOrderEvent]:
 
     # asyncio.gather() returns the results in the same order as the input list, so we can zip the two lists
     # https://docs.python.org/3/library/asyncio-task.html#running-tasks-concurrently
-    for transaction, log in zip(transactions, set_order_logs):
+    for log, transaction in zip(set_order_logs, transactions):
         from_address = transaction['from']
         zksync_log = ZksyncLog(**log, from_address=from_address)
         # Create a list of tasks to parallelize the creation of the SetOrderEvent list

--- a/mm-bot/src/services/zksync.py
+++ b/mm-bot/src/services/zksync.py
@@ -72,8 +72,7 @@ async def get_set_order_events(from_block, to_block) -> list[SetOrderEvent]:
     order_tasks = []
 
     for log in set_order_logs:
-        log_task = asyncio.create_task(get_tx(log['transactionHash']))
-        log_tasks.append(log_task)
+        log_tasks.append(asyncio.create_task(get_tx(log['transactionHash'])))
 
     transactions = await asyncio.gather(*log_tasks)
 


### PR DESCRIPTION
## Description
- Save from_address from set order events for zkSync and Starknet in order to use it later in the explorer.
## Results
- From_address field is stored in the mm-bot database in the orders table.