### PR TITLE
feat(mm bot): add long range orders processor for zksync

### DIFF
--- a/mm-bot/src/main.py
+++ b/mm-bot/src/main.py
@@ -22,6 +22,7 @@ from services.payment_claimer.herodotus_payment_claimer import HerodotusPaymentC
 from services.payment_claimer.payment_claimer import PaymentClaimer
 from services.processors.accepted_blocks_orders_processor import AcceptedBlocksOrdersProcessor
 from services.processors.failed_orders_processor import FailedOrdersProcessor
+from services.processors.long_range_orders_processor import LongRangeOrdersProcessor
 from services.processors.orders_processor import OrdersProcessor
 from services.senders.ethereum_sender import EthereumSender
 
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 SLEEP_TIME = 5
 PROCESS_FAILED_ORDERS_MINUTES_TIMER = 5
 PROCESS_ACCEPTED_BLOCKS_MINUTES_TIMER = 5
+PROCESS_LONG_RANGE_ORDERS_MINUTES_TIMER = 5
 MAX_ETH_TRANSFER_WEI = 100000000000000000  # TODO move to env variable
 
 
@@ -86,6 +88,12 @@ async def run():
      .do(failed_orders_processor.process_orders_job))
     (schedule.every(PROCESS_ACCEPTED_BLOCKS_MINUTES_TIMER).minutes
      .do(accepted_blocks_orders_processor.process_orders_job))
+
+    # Initialize long range orders processor for ZkSync
+    long_range_orders_processor = LongRangeOrdersProcessor(zksync_order_indexer, zksync_order_executor, block_dao)
+
+    (schedule.every(PROCESS_LONG_RANGE_ORDERS_MINUTES_TIMER).minutes
+     .do(long_range_orders_processor.process_orders_job))
 
     try:
         # Get all orders that are not completed from the db

--- a/mm-bot/src/main.py
+++ b/mm-bot/src/main.py
@@ -84,13 +84,13 @@ async def run():
     accepted_blocks_orders_processor = AcceptedBlocksOrdersProcessor(starknet_order_indexer, starknet_order_executor,
                                                                      block_dao)
 
+    # Initialize long range orders processor for zksync
+    long_range_orders_processor = LongRangeOrdersProcessor(zksync_order_indexer, zksync_order_executor, block_dao)
+
     (schedule.every(PROCESS_FAILED_ORDERS_MINUTES_TIMER).minutes
      .do(failed_orders_processor.process_orders_job))
     (schedule.every(PROCESS_ACCEPTED_BLOCKS_MINUTES_TIMER).minutes
      .do(accepted_blocks_orders_processor.process_orders_job))
-
-    # Initialize long range orders processor for ZkSync
-    long_range_orders_processor = LongRangeOrdersProcessor(zksync_order_indexer, zksync_order_executor, block_dao)
 
     (schedule.every(PROCESS_LONG_RANGE_ORDERS_MINUTES_TIMER).minutes
      .do(long_range_orders_processor.process_orders_job))

--- a/mm-bot/src/services/ethereum.py
+++ b/mm-bot/src/services/ethereum.py
@@ -39,7 +39,7 @@ def get_latest_block(rpc_node=main_rpc_node) -> int:
 
 @use_fallback(rpc_nodes, logger, "Failed to get order status")
 def get_is_used_order(order_id, recipient_address, amount, chain_id, rpc_node=main_rpc_node) -> bool:
-    order_data = Web3.solidity_keccak(['uint256', 'address', 'uint256', 'uint8'],
+    order_data = Web3.solidity_keccak(['uint256', 'address', 'uint256', 'uint128'],
                                       [order_id, Web3.to_checksum_address(recipient_address), amount, chain_id])
     is_used = rpc_node.contract.functions.transfers(order_data).call()
     return is_used

--- a/mm-bot/src/services/processors/accepted_blocks_orders_processor.py
+++ b/mm-bot/src/services/processors/accepted_blocks_orders_processor.py
@@ -1,22 +1,11 @@
 import asyncio
-import logging
 
 from models.network import Network
-from persistence.block_dao import BlockDao
 from services import starknet
-from services.executors.order_executor import OrderExecutor
-from services.indexers.order_indexer import OrderIndexer
+from services.processors.catch_up_orders_processor import CatchUpOrdersProcessor
 
 
-class AcceptedBlocksOrdersProcessor:
-
-    def __init__(self, order_indexer: OrderIndexer,
-                 order_executor: OrderExecutor,
-                 block_dao: BlockDao):
-        self.logger = logging.getLogger(__name__)
-        self.order_indexer: OrderIndexer = order_indexer
-        self.order_executor: OrderExecutor = order_executor
-        self.block_dao: BlockDao = block_dao
+class AcceptedBlocksOrdersProcessor(CatchUpOrdersProcessor):
 
     async def process_orders(self, ):
         """

--- a/mm-bot/src/services/processors/catch_up_orders_processor.py
+++ b/mm-bot/src/services/processors/catch_up_orders_processor.py
@@ -1,0 +1,31 @@
+import logging
+from abc import ABC, abstractmethod
+
+from persistence.block_dao import BlockDao
+from services.executors.order_executor import OrderExecutor
+from services.indexers.order_indexer import OrderIndexer
+
+
+class CatchUpOrdersProcessor(ABC):
+
+    def __init__(self, order_indexer: OrderIndexer,
+                 order_executor: OrderExecutor,
+                 block_dao: BlockDao):
+        self.logger = logging.getLogger(__name__)
+        self.order_indexer: OrderIndexer = order_indexer
+        self.order_executor: OrderExecutor = order_executor
+        self.block_dao: BlockDao = block_dao
+
+    @abstractmethod
+    async def process_orders(self):
+        """
+
+        """
+        pass
+
+    @abstractmethod
+    def process_orders_job(self):
+        """
+        Process orders job for the scheduler
+        """
+        pass

--- a/mm-bot/src/services/processors/long_range_orders_processor.py
+++ b/mm-bot/src/services/processors/long_range_orders_processor.py
@@ -1,0 +1,30 @@
+import asyncio
+
+from models.network import Network
+from services import zksync
+from services.processors.catch_up_orders_processor import CatchUpOrdersProcessor
+
+# The maximum number of blocks that can be queried in a single request is 500.
+# https://docs.blastapi.io/blast-documentation/apis-documentation/core-api/oktc/eth_getlogs#limits
+BLOCK_BATCH_SIZE = 500
+
+
+class LongRangeOrdersProcessor(CatchUpOrdersProcessor):
+
+    async def process_orders(self):
+        try:
+            latest_block = self.block_dao.get_latest_block(Network.ZKSYNC)
+            new_latest_block = await zksync.get_latest_block()
+
+            for order_block in range(latest_block, new_latest_block, BLOCK_BATCH_SIZE):
+                end_block = min(order_block + BLOCK_BATCH_SIZE, new_latest_block)
+                orders = await self.order_indexer.get_orders(order_block, end_block)
+                for order in orders:
+                    self.order_executor.execute(order)
+            self.block_dao.update_latest_block(new_latest_block, Network.ZKSYNC)
+        except Exception as e:
+            self.logger.error(f"[-] Error: {e}")
+
+    def process_orders_job(self):
+        asyncio.create_task(self.process_orders(),
+                            name="Long Range Orders")


### PR DESCRIPTION
# Description
- Add long range orders processor for zkSync in order to catch up the processed blocks from the last one present in the database to the last one on the network.
# Results
- Blocks are processed in batches of 500 until the latest block from the zkSync network is reached.